### PR TITLE
Swap `VaadinSession.getCurrent()` to `Session.current`

### DIFF
--- a/docs/gettingstarted-v10.md
+++ b/docs/gettingstarted-v10.md
@@ -1468,7 +1468,6 @@ We will implement a login service and a login form. Just create the `web/src/mai
 package com.example.vok
 
 import com.vaadin.flow.component.UI
-import com.vaadin.flow.server.VaadinSession
 import eu.vaadinonkotlin.vaadin10.Session
 import java.io.Serializable
 
@@ -1486,7 +1485,7 @@ class LoginService : Serializable {
         private set
 
     fun logout() {
-        VaadinSession.getCurrent().close()
+        Session.current.close()
         UI.getCurrent().navigate("")
         UI.getCurrent().page.reload()
     }

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -1509,7 +1509,7 @@ class LoginService : Serializable {
     private set
 
     fun logout() {
-        VaadinSession.getCurrent().close()
+        Session.current.close()
         Page.getCurrent().reload()
     }
 

--- a/docs/gettingstartedjpa.md
+++ b/docs/gettingstartedjpa.md
@@ -1507,7 +1507,7 @@ object LoginService {
     }
     val currentUser: User? get() = Session[User::class]
     fun logout() {
-        VaadinSession.getCurrent().close()
+        Session.current.close()
         Page.getCurrent().reload()
     }
 }

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -61,7 +61,7 @@ method or in the constructor of your root layout class.
 * As a first step, you can check whether the user has configured his language in his settings. Just get the current
 user from the session, then do a database lookup for the user settings and retrieve the locale. If it's not null, use it.
 * If user haven't configured his locale or your app doesn't support this kind of functionality, fall back and simply poll the browser
-for the `WebBrowser.locale`: Vaadin 8: `Page.getCurrent().webBrowser.locale`, Vaadin 10: `VaadinSession.getCurrent().browser.locale`.
+for the `WebBrowser.locale`: Vaadin 8: `Page.getCurrent().webBrowser.locale`, Vaadin 10: `Session.current.browser.locale`.
 * If the browser provided `null` locale, fall back to `Locale.ENGLISH`.
 * Set the value computed by the steps above to the UI: `UI.setLocale`
 

--- a/vok-example-crud-flow/src/main/kotlin/example/crudflow/MainLayout.kt
+++ b/vok-example-crud-flow/src/main/kotlin/example/crudflow/MainLayout.kt
@@ -4,9 +4,9 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.page.BodySize
 import com.vaadin.flow.component.page.Viewport
 import com.vaadin.flow.router.RouterLayout
-import com.vaadin.flow.server.VaadinSession
 import com.vaadin.flow.theme.Theme
 import com.vaadin.flow.theme.lumo.Lumo
+import eu.vaadinonkotlin.vaadin10.Session
 import java.util.*
 
 /**
@@ -18,6 +18,6 @@ import java.util.*
 class MainLayout : VerticalLayout(), RouterLayout {
     init {
         setSizeFull()
-        VaadinSession.getCurrent().locale = VaadinSession.getCurrent().browser.locale ?: Locale.getDefault()
+        Session.current.locale = Session.current.browser.locale ?: Locale.getDefault()
     }
 }

--- a/vok-util-vaadin10/src/main/kotlin/eu/vaadinonkotlin/vaadin10/VaadinUtils.kt
+++ b/vok-util-vaadin10/src/main/kotlin/eu/vaadinonkotlin/vaadin10/VaadinUtils.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KProperty1
  * * As a first step, you can check whether the user has configured his language in his settings. Just get the current
  * user from the session, then do a database lookup for the user settings and retrieve the locale. If it's not null, use it.
  * * If user haven't configured his locale or your app doesn't support this kind of functionality, fall back and simply poll the browser
- * for the [com.vaadin.flow.server.WebBrowser.locale]: `VaadinSession.getCurrent().browser.locale`
+ * for the [com.vaadin.flow.server.WebBrowser.locale]: `Session.current.browser.locale`
  * * If the browser provided `null` locale, fall back to [java.util.Locale.ENGLISH].
  * * Set the value computed by the steps above to the UI: [UI.setLocale]
  *


### PR DESCRIPTION
Since I believe the intent is for users to use `eu.vaadinonkotlin.vaadin10.Session`, I used it instead of `VaadinSession` directly.